### PR TITLE
fix(git): update .gitignore to exclude modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# REANA modules for local development
+modules/


### PR DESCRIPTION
For local development we populate the modules directory with local versions of shared REANA modules (reana-commons, reana-db) so that changes to shared modules are reflected in each component. This led to a lot of untracked files, which was confusing for new developers.

Closes reanahub/reana#963